### PR TITLE
Fixed cloneNode(deep) for the last DOM4 spec

### DIFF
--- a/workbench_template.ts
+++ b/workbench_template.ts
@@ -3,7 +3,7 @@ var socket = (function(){
     var shadowBody = null
     var bootSnippet = "<bootSnippet>"
     window.onload = function(){
-        shadowBody = document.body.cloneNode()
+        shadowBody = document.body.cloneNode(true)
     }
     window.addEventListener("keydown", function (event) {
         if(event.keyCode==13 && event.ctrlKey && event.altKey && event.shiftKey) {
@@ -12,7 +12,7 @@ var socket = (function(){
         }
     })
     function clear(){
-        document.body = shadowBody.cloneNode()
+        document.body = shadowBody.cloneNode(true)
         for(var i = 0; i < 99999; i++){
             clearTimeout(i)
             clearInterval(i)


### PR DESCRIPTION
The DOM4 spec for `cloneNode(deep)` has changed recently: https://developer.mozilla.org/en-US/docs/Web/API/Node.cloneNode#Specifications

I've noticed it because scala-js-workbench stopped working after a Chrome update.

Passing `true` doesn't harm older browsers.
