### PR TITLE
Fixed a bug where everything would crash if the page loaded slowly

### DIFF
--- a/workbench_template.js
+++ b/workbench_template.js
@@ -3,6 +3,7 @@
     var bootSnippet = "<bootSnippet>"
     window.onload = function(){
         shadowBody = document.body.cloneNode(true)
+        start()
     }
     window.addEventListener("keydown", function (event) {
         if(event.keyCode==13 && event.ctrlKey && event.altKey && event.shiftKey) {
@@ -65,5 +66,4 @@
         }
         req.send()
     }
-    start()
 })()


### PR DESCRIPTION
If a `clear` command is sent before the `shadowBody` is  initialized everything crashes. I have moved the `start` call inside the window.onload to fix this.
