### PR TITLE
Fixes client to POST at /notifications instead of the address where the server is bound.

### DIFF
--- a/client/src/main/scala/workbench/WorkbenchClient.scala
+++ b/client/src/main/scala/workbench/WorkbenchClient.scala
@@ -27,9 +27,9 @@ object WorkbenchClient extends Api{
   @JSExport
   var success = false
   @JSExport
-  def main(bootSnippet: String, host: String, port: Int): Unit = {
+  def main(bootSnippet: String): Unit = {
     def rec(): Unit = {
-      Ajax.post(s"http://$host:$port/notifications").onComplete {
+      Ajax.post(s"/notifications").onComplete {
         case util.Success(data) =>
           if (!success) println("Workbench connected")
           success = true

--- a/src/main/scala/workbench/Server.scala
+++ b/src/main/scala/workbench/Server.scala
@@ -107,7 +107,7 @@ class Server(url: String, port: Int, bootSnippet: String) extends SimpleRoutingA
           (function(){
             $body
 
-            WorkbenchClient().main(${upickle.write(bootSnippet)}, ${upickle.write(url)}, ${upickle.write(port)})
+            WorkbenchClient().main(${upickle.write(bootSnippet)})
           }).call(this)
           """
         }


### PR DESCRIPTION
To have other machines in my network being able to access the workbench (a VM with another operating system, e.g), I've put;

``` scala
localUrl := ("0.0.0.0", 12345)
```

in my `build.sbt`.

However, the clients on those other machines cannot get the notifications because they try to obtain them by POSTing to `http://$host:$port/notifications`.

I've fixed that by changing the POST target to simply `/notifications` and removing the unused parameters.
