### PR TITLE
General Update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,7 @@
 import sbt.Keys._
 
-val scalaJsVersion = "0.6.2"
-
 val defaultSettings = Seq(
+  scalacOptions ++= Seq("-feature", "-deprecation"),
   unmanagedSourceDirectories in Compile += baseDirectory.value /  "shared" / "main" / "scala",
   unmanagedSourceDirectories in Test += baseDirectory.value / "shared" / "test" / "scala"
 )
@@ -11,7 +10,7 @@ lazy val root = project.in(file(".")).settings(defaultSettings:_*).settings(
   name := "workbench",
   version := "0.3.0-SNAPSHOT",
   organization := "com.lihaoyi",
-  scalaVersion := "2.10.5",
+  scalaVersion := "2.10.6",
   sbtPlugin := true,
   publishArtifact in Test := false,
   publishTo := Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
@@ -39,30 +38,25 @@ lazy val root = project.in(file(".")).settings(defaultSettings:_*).settings(
     (fullOptJS in (client, Compile)).value
     (artifactPath in (client, Compile, fullOptJS)).value
   },
-  resolvers += Resolver.url("scala-js-releases",
-    url("http://dl.bintray.com/content/scala-js/scala-js-releases"))(
-    Resolver.ivyStylePatterns),
-  addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.1"),
+  addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13"),
   libraryDependencies ++= Seq(
-    "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-    "io.spray" % "spray-can" % "1.3.1",
-    "io.spray" % "spray-routing" % "1.3.1",
-    "com.typesafe.akka" %% "akka-actor" % "2.3.9",
-    "org.scala-lang.modules" %% "scala-async" % "0.9.3" % "provided",
-    "com.lihaoyi" %% "autowire" % "0.2.5",
-    "com.lihaoyi" %% "upickle" % "0.2.8"
-  ),
-  resolvers += "bintray/non" at "http://dl.bintray.com/non/maven"
+    Dependencies.sprayCan,
+    Dependencies.sprayRouting,
+    Dependencies.akka,
+    Dependencies.autowire.value,
+    Dependencies.upickle.value
+  )
 )
 
-lazy val client = project.in(file("client")).enablePlugins(ScalaJSPlugin)
-                         .settings(defaultSettings: _*)
-                         .settings(
-  unmanagedSourceDirectories in Compile += baseDirectory.value /  ".." / "shared" / "main" / "scala",
-  libraryDependencies ++= Seq(
-    "org.scala-js" %%% "scalajs-dom" % "0.8.0",
-    "com.lihaoyi" %%% "autowire" % "0.2.4",
-    "com.lihaoyi" %%% "upickle" % "0.2.6"
-  ),
-  emitSourceMaps := false
-)
+lazy val client = project.in(file("client"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(defaultSettings: _*)
+  .settings(
+    unmanagedSourceDirectories in Compile += baseDirectory.value / ".." / "shared" / "main" / "scala",
+    libraryDependencies ++= Seq(
+      Dependencies.autowire.value,
+      Dependencies.dom.value,
+      Dependencies.upickle.value
+    ),
+    emitSourceMaps := false
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,13 @@ import sbt.Keys._
 val scalaJsVersion = "0.6.2"
 
 val defaultSettings = Seq(
-  unmanagedSourceDirectories in Compile <+= baseDirectory(_ /  "shared" / "main" / "scala"),
-  unmanagedSourceDirectories in Test <+= baseDirectory(_ / "shared" / "test" / "scala")
+  unmanagedSourceDirectories in Compile += baseDirectory.value /  "shared" / "main" / "scala",
+  unmanagedSourceDirectories in Test += baseDirectory.value / "shared" / "test" / "scala"
 )
 
 lazy val root = project.in(file(".")).settings(defaultSettings:_*).settings(
   name := "workbench",
-  version := "0.2.3",
+  version := "0.3.0-SNAPSHOT",
   organization := "com.lihaoyi",
   scalaVersion := "2.10.5",
   sbtPlugin := true,
@@ -41,8 +41,8 @@ lazy val root = project.in(file(".")).settings(defaultSettings:_*).settings(
   },
   resolvers += Resolver.url("scala-js-releases",
     url("http://dl.bintray.com/content/scala-js/scala-js-releases"))(
-      Resolver.ivyStylePatterns),
-  addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJsVersion),
+    Resolver.ivyStylePatterns),
+  addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.1"),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     "io.spray" % "spray-can" % "1.3.1",
@@ -58,7 +58,7 @@ lazy val root = project.in(file(".")).settings(defaultSettings:_*).settings(
 lazy val client = project.in(file("client")).enablePlugins(ScalaJSPlugin)
                          .settings(defaultSettings: _*)
                          .settings(
-  unmanagedSourceDirectories in Compile <+= baseDirectory(_ /  ".." / "shared" / "main" / "scala"),
+  unmanagedSourceDirectories in Compile += baseDirectory.value /  ".." / "shared" / "main" / "scala",
   libraryDependencies ++= Seq(
     "org.scala-js" %%% "scalajs-dom" % "0.8.0",
     "com.lihaoyi" %%% "autowire" % "0.2.4",

--- a/client/src/main/scala/workbench/WorkbenchClient.scala
+++ b/client/src/main/scala/workbench/WorkbenchClient.scala
@@ -1,20 +1,22 @@
 package com.lihaoyi.workbench
-import upickle._
+import upickle.Js
+import upickle.default
+import upickle.default.{Reader, Writer}
+import upickle.json
 import org.scalajs.dom
 import org.scalajs.dom.ext._
-import upickle.{Reader, Writer, Js}
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExport
-import scalajs.concurrent.JSExecutionContext.Implicits.runNow
+import scalajs.concurrent.JSExecutionContext.Implicits.queue
 import org.scalajs.dom.raw._
 
 /**
  * The connection from workbench server to the client
  */
-object Wire extends autowire.Server[Js.Value, upickle.Reader, upickle.Writer] with ReadWrite{
+object Wire extends autowire.Server[Js.Value, Reader, Writer] with ReadWrite{
   def wire(parsed: Js.Arr): Unit = {
     val Js.Arr(path, args: Js.Obj) = parsed
-    val req = new Request(upickle.readJs[Seq[String]](path), args.value.toMap)
+    val req = new Request(default.readJs[Seq[String]](path), args.value.toMap)
     Wire.route[Api](WorkbenchClient).apply(req)
   }
 }
@@ -28,7 +30,7 @@ object WorkbenchClient extends Api{
   @JSExport
   var success = false
   @JSExport
-  def main(bootSnippet: String, host: String, port: Int): Unit = {
+  def main(host: String, port: Int): Unit = {
     def rec(): Unit = {
       Ajax.post(s"http://$host:$port/notifications").onComplete {
         case util.Success(data) =>
@@ -44,7 +46,7 @@ object WorkbenchClient extends Api{
           if (success) println("Workbench disconnected " + e)
           success = false
           interval = math.min(interval * 2, 30000)
-          dom.setTimeout(() => rec(), interval)
+          dom.window.setTimeout(() => rec(), interval)
       }
     }
 
@@ -59,31 +61,19 @@ object WorkbenchClient extends Api{
   override def clear(): Unit = {
     dom.document.asInstanceOf[js.Dynamic].body = shadowBody.cloneNode(true)
     for(i <- 0 until 100000){
-      dom.clearTimeout(i)
-      dom.clearInterval(i)
+      dom.window.clearTimeout(i)
+      dom.window.clearInterval(i)
     }
   }
   @JSExport
   override def reload(): Unit = {
     dom.console.log("Reloading page...")
-    dom.location.reload()
+    dom.window.location.reload()
   }
   @JSExport
-  override def run(path: String, bootSnippet: Option[String]): Unit = {
+  override def run(path: String): Unit = {
     val tag = dom.document.createElement("script").asInstanceOf[HTMLElement]
-    var loaded = false
-
     tag.setAttribute("src", path)
-    bootSnippet.foreach{ bootSnippet =>
-      tag.onreadystatechange = (e: dom.Event) => {
-        if (!loaded) {
-          dom.console.log("Workbench reboot")
-          js.eval(bootSnippet)
-        }
-        loaded = true
-      }
-      tag.asInstanceOf[js.Dynamic].onload = tag.onreadystatechange
-    }
     dom.document.head.appendChild(tag)
   }
   @JSExport

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,5 +1,10 @@
 enablePlugins(ScalaJSPlugin)
+
+// dynamic page reloading
 enablePlugins(WorkbenchPlugin)
+
+// (experimental feature) in-place code update with state preservation
+// enablePlugins(WorkbenchSplicePlugin) // disable WorkbenchPlugin when activating
 
 name := "Example"
 
@@ -10,6 +15,3 @@ version := "0.1-SNAPSHOT"
 libraryDependencies ++= Seq(
   "org.scala-js" %%% "scalajs-dom" % "0.9.1"
 )
-
-// (experimental feature)
-spliceBrowsers <<= spliceBrowsers.triggeredBy(fastOptJS in Compile)

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,25 +1,15 @@
-import com.lihaoyi.workbench.Plugin._
-
-// Turn this project into a Scala.js project by importing these settings
 enablePlugins(ScalaJSPlugin)
-
-workbenchSettings
+enablePlugins(WorkbenchPlugin)
 
 name := "Example"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.12.0"
 
 version := "0.1-SNAPSHOT"
 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
-
 libraryDependencies ++= Seq(
-  "org.scala-js" %%% "scalajs-dom" % "0.8.0"
+  "org.scala-js" %%% "scalajs-dom" % "0.9.1"
 )
 
-bootSnippet := "ScalaJSExample().main();"
-
-disableOptimizer := true
-
+// (experimental feature)
 spliceBrowsers <<= spliceBrowsers.triggeredBy(fastOptJS in Compile)
-

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.13

--- a/example/project/build.sbt
+++ b/example/project/build.sbt
@@ -1,4 +1,3 @@
-
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
 lazy val root = project.in(file(".")).dependsOn(file("../.."))

--- a/example/src/main/resources/index-dev.html
+++ b/example/src/main/resources/index-dev.html
@@ -14,7 +14,7 @@
 <script type="text/javascript" src="../example-fastopt.js"></script>
 
 <script>
-    ScalaJSExample().main();
+    example.ScalaJSExample().main();
 </script>
 </body>
 </html>

--- a/example/src/main/resources/index-opt.html
+++ b/example/src/main/resources/index-opt.html
@@ -12,7 +12,7 @@
 
 <script type="text/javascript" src="../example-opt.js"></script>
 <script>
-    ScalaJSExample().main();
+    example.ScalaJSExample().main();
 </script>
 </body>
 </html>

--- a/example/src/main/scala/example/ScalaJSExample.scala
+++ b/example/src/main/scala/example/ScalaJSExample.scala
@@ -1,6 +1,7 @@
 package example
 import scala.scalajs.js.annotation.JSExport
 import org.scalajs.dom
+import org.scalajs.dom.html
 import scala.util.Random
 
 case class Point(x: Int, y: Int){
@@ -8,14 +9,12 @@ case class Point(x: Int, y: Int){
   def /(d: Int) = Point(x / d, y / d)
 }
 
-// Seems like you need this for sbt ~fastOptJS to work
-// mkdir ~/.sbt/0.13/plugins/target/scala-2.10/sbt-0.13/classes
 @JSExport
 object ScalaJSExample {
   val ctx =
     dom.document
        .getElementById("canvas")
-       .asInstanceOf[dom.HTMLCanvasElement]
+       .asInstanceOf[html.Canvas]
        .getContext("2d")
        .asInstanceOf[dom.CanvasRenderingContext2D]
 
@@ -41,6 +40,6 @@ object ScalaJSExample {
   }
   @JSExport
   def main(): Unit = {
-    dom.setInterval(() => run, 10)
+    dom.window.setInterval(() => run, 10)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,16 @@
+import sbt._
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+
+object Dependencies {
+
+  // jvm dependencies
+  val sprayCan = "io.spray" % "spray-can" % "1.3.1"
+  val sprayRouting = "io.spray" % "spray-routing" % "1.3.1"
+  val akka = "com.typesafe.akka" %% "akka-actor" % "2.3.15"
+
+  // js and shared dependencies
+  val autowire = Def.setting("com.lihaoyi" %%% "autowire" % "0.2.6")
+  val dom = Def.setting("org.scala-js" %%% "scalajs-dom" % "0.9.1")
+  val upickle = Def.setting("com.lihaoyi" %%% "upickle" % "0.4.3")
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-workbench 0.2.3
+workbench 0.3.0
 ---------------
 
 ![Example](https://github.com/lihaoyi/scala-js-workbench/blob/master/Example.png?raw=true)
@@ -7,32 +7,19 @@ A SBT plugin for [scala-js](https://github.com/lampepfl/scala-js) projects to ma
 
 - Spins up a local web server on (by default) `localhost:12345`, whenever you're in the SBT console. Navigate to localhost:12345 in the browser and it'll show a simple page tell you it's alive. You can access any file within your project directory by going to `localhost:12345/path/to/file` in a browser.
 - Forwards all SBT logging from your SBT console to the browser console, so you can see what's going on (e.g. when the project is recompiling) without having to flip back and forth between browser and terminal.
-- Sends commands to tell the connected browsers to refresh/update every time your Scala.Js project completes a `packageJS`.
+- Sends commands to tell the connected browsers to refresh/update every time your Scala.Js project completes a `fastOptJS`.
 
 Check out the [example app](https://github.com/lihaoyi/workbench-example-app) for a plug-and-play example of workbench in action.
 
 Installation
 ------------
-
 - Add to your `project/plugins.sbt`
 ```scala
-resolvers += "spray repo" at "http://repo.spray.io"
-
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
-
-addSbtPlugin("com.lihaoyi" % "workbench" % "0.2.3")
+addSbtPlugin("com.lihaoyi" % "workbench" % "0.3.0")
 ```
 - Add to your `build.sbt`
 ```scala
-workbenchSettings
-```
-If you're using `project/Build.scala` or similar, also  add:
-```scala
-import com.lihaoyi.workbench.Plugin._
-```
-- So that workbench knows how to restart your application, specify a `bootSnippet` property in your SBT build, which is a javascript command to start your application, e.g.
-```scala
-bootSnippet := "ScalaJSExample().main();"
+enablePlugins(WorkbenchPlugin)
 ```
 - For all web pages you would like to integrate with workbench, add
 ```html
@@ -41,50 +28,20 @@ bootSnippet := "ScalaJSExample().main();"
 
 ### Usage
 
-Once the above installation steps are completed, simply open your desired HTML file via `http://localhost:12345` with the URL path being any file part relative to your project root. e.g. `localhost:12345/target/scala-2.10/classes/index.html`. This should serve up the HTML file and connect it to workbench.
+Once the above installation steps are completed, simply open your desired HTML file via `http://localhost:12345` with the URL path being any file part relative to your project root. e.g. `localhost:12345/target/scala-2.12/classes/index.html`. This should serve up the HTML file and connect it to workbench.
 
 
 # Live Reloading
 
 You have a choice of what you want to do when the code compiles.
 
-#### refreshBrowsers
+#### Refresh page
+This will to make any client browsers refresh every time `fastOptJS` completes, saving you flipping back and forth between SBT and the browser to refresh the page after compilation is finished. This is the default behavior.
 
+#### Splice changes
 ```scala
-refreshBrowsers <<= refreshBrowsers.triggeredBy(packageJS in Compile)
-```
-
-This will to make any client browsers refresh every time `packageJS` completes, saving you flipping back and forth between SBT and the browser to refresh the page after compilation is finished.
-
-#### updateBrowsers
-
-```scala
-updateBrowsers <<= updateBrowsers.triggeredBy(packageJS in Compile)
-```
-
-This will attempt to perform an update without refreshing the page every time `fastOptJS` completes. This involves:
-
-- Returning the state of `document.body` to the initial state before any javascript was run
-- Stripping all event listeners from things within body
-- Clearing all repeated timeouts and intervals
-- Running the `bootSnippet` again
-
-`updateBrowsers` is a best-effort cleanup, and does not do things like:
-
-- clear up outstanding websocket/ajax connections
-- undo modifications done to `window` or `document`
-- mutations to global javascript objects
-
-Nonetheless, for the bulk of javascript libraries these limitations are acceptable. As long as you're not doing anything too crazy, `updateBrowsers` but should suffice for most applications.
-
-You can force the clean-up-and-reboot to happen from the browser via the shortcut Ctrl-Alt-Shift-Enter if you simply wish to reset the browser to a clean state.
-
-#### spliceBrowsers
-
-```scala
-ScalaJSKeys.inliningMode := scala.scalajs.sbtplugin.InliningMode.Off
-
-spliceBrowsers <<= spliceBrowsers.triggeredBy(ScalaJSKeys.fastOptJS in Compile)
+// WorkbenchPlugin must NOT be enabled at the same time
+enablePlugins(WorkbenchSplicePlugin)
 ```
 
 This is an experimental feature that aims to perform an update to the code running in the browser *without losing the state of the running code*! Thus you can make changes to the code and have them immediately appear in the program, without having to restart and lose the current state of the application. See [this video](https://vimeo.com/105852957) for a demo of it in action.  
@@ -124,17 +81,22 @@ With this done, you should be receiving the SBT logspam (compilation, warnings, 
 To develop, go into `example/` and run `sbt ~fastOptJS`. Then you can go to
 
 ```
-http://localhost:12345/target/scala-2.11/classes/index-dev.html
+http://localhost:12345/target/scala-2.12/classes/index-dev.html
 ```
 
 and see a small sierpinski-triangle application. Editing the code within `example/` should cause the SBT log-spam to appear in the browser console, and changes (e.g. changing the color of the background fill) should cause a recompile and updating of the browser animation.
 
-To make changes to workbench, modify the workbench source code and stop/re-run `sbt ~fastOptJS`. When workbench finishes re-compiling, SBT re-starts and the page becomes accessible, your changes to workbench will take effect. You can replace `fullOptJs` in the `built.sbt` file with `fastOptJS`, and swapping the reference to `client-opt.js` to `client-fastopt.js`, if you want to speed up the development cycle.
+To make changes to workbench, modify the workbench source code and stop/re-run `sbt ~fastOptJS`. When workbench finishes re-compiling, SBT re-starts and the page becomes accessible, your changes to workbench will take effect.
 
 Pull requests welcome!
 
 Change Log
 ----------
+
+##0.3.0
+- Migration to AutoPlugins
+- Removal of `updateBrowsers` feature, made obsolete by increased speed of `fastOptJS`
+- General upgrade of dependencies
 
 ##0.2.3
 

--- a/shared/main/scala/workbench/Shared.scala
+++ b/shared/main/scala/workbench/Shared.scala
@@ -1,13 +1,15 @@
 package com.lihaoyi.workbench
 
-import upickle.{Js, Reader, Writer}
+import upickle.default.{Reader, Writer}
+import upickle.Js
+
 
 /**
  * A standard way to read and write `Js.Value`s with autowire/upickle
  */
 trait ReadWrite{
-  def write[Result: Writer](r: Result) = upickle.writeJs(r)
-  def read[Result: Reader](p: Js.Value) = upickle.readJs[Result](p)
+  def write[Result: Writer](r: Result) = upickle.default.writeJs(r)
+  def read[Result: Reader](p: Js.Value) = upickle.default.readJs[Result](p)
 }
 
 /**
@@ -31,8 +33,7 @@ trait Api{
   def print(level: String, msg: String): Unit
 
   /**
-   * Execute the javascript file available at the given `path`. Optionally,
-   * run a `bootSnippet` after the file has been executed.
+   * Execute the javascript file available at the given `path`.
    */
-  def run(path: String, bootSnippet: Option[String]): Unit
+  def run(path: String): Unit
 }

--- a/src/main/scala/workbench/Server.scala
+++ b/src/main/scala/workbench/Server.scala
@@ -8,13 +8,13 @@ import spray.httpx.encoding.Gzip
 import spray.routing.SimpleRoutingApp
 import akka.actor.ActorDSL._
 
-import upickle.{Reader, Writer, Js}
+import upickle.Js
+import upickle.default.{Reader, Writer}
 import spray.http.{HttpEntity, AllOrigins, HttpResponse}
 import spray.http.HttpHeaders.`Access-Control-Allow-Origin`
 import concurrent.duration._
 import scala.concurrent.Future
 import scala.io.Source
-import org.scalajs.core.tools.optimizer.{ScalaJSClosureOptimizer, ScalaJSOptimizer}
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.logging.Level
 import scala.tools.nsc
@@ -24,12 +24,11 @@ import scala.tools.nsc.backend.JavaPlatform
 import scala.tools.nsc.util.ClassPath.JavaContext
 import scala.collection.mutable
 import scala.tools.nsc.typechecker.Analyzer
-import org.scalajs.core.tools.classpath.{CompleteClasspath, PartialClasspath}
 import scala.tools.nsc.util.{JavaClassPath, DirectoryClassPath}
 import spray.http.HttpHeaders._
 import spray.http.HttpMethods._
 
-class Server(url: String, port: Int, bootSnippet: String) extends SimpleRoutingApp{
+class Server(url: String, port: Int) extends SimpleRoutingApp{
   val corsHeaders: List[ModeledHeader] =
     List(
       `Access-Control-Allow-Methods`(OPTIONS, GET, POST),
@@ -47,9 +46,9 @@ class Server(url: String, port: Int, bootSnippet: String) extends SimpleRoutingA
   /**
    * The connection from workbench server to the client
    */
-  object Wire extends autowire.Client[Js.Value, upickle.Reader, upickle.Writer] with ReadWrite{
+  object Wire extends autowire.Client[Js.Value, Reader, Writer] with ReadWrite{
     def doCall(req: Request): Future[Js.Value] = {
-      longPoll ! Js.Arr(upickle.writeJs(req.path), Js.Obj(req.args.toSeq:_*))
+      longPoll ! Js.Arr(upickle.default.writeJs(req.path), Js.Obj(req.args.toSeq:_*))
       Future.successful(Js.Null)
     }
   }
@@ -68,7 +67,7 @@ class Server(url: String, port: Int, bootSnippet: String) extends SimpleRoutingA
     case object Clear
     import system.dispatcher
 
-    system.scheduler.schedule(0 seconds, 10 seconds, self, Clear)
+    system.scheduler.schedule(0.seconds, 10.seconds, self, Clear)
     def respond(a: ActorRef, s: String) = {
       a ! HttpResponse(
         entity = s,
@@ -116,7 +115,7 @@ class Server(url: String, port: Int, bootSnippet: String) extends SimpleRoutingA
           (function(){
             $body
 
-            com.lihaoyi.workbench.WorkbenchClient().main(${upickle.write(bootSnippet)}, ${upickle.write(url)}, ${upickle.write(port)})
+            com.lihaoyi.workbench.WorkbenchClient().main(${upickle.default.write(url)}, ${upickle.default.write(port)})
           }).call(this)
           """
         }

--- a/src/main/scala/workbench/WorkbenchBasePlugin.scala
+++ b/src/main/scala/workbench/WorkbenchBasePlugin.scala
@@ -1,0 +1,124 @@
+package com.lihaoyi.workbench
+import scala.concurrent.ExecutionContext.Implicits.global
+import sbt._
+import sbt.Keys._
+import autowire._
+import org.scalajs.sbtplugin.ScalaJSPlugin
+import org.scalajs.core.tools.io._
+import org.scalajs.sbtplugin.ScalaJSPluginInternal._
+import org.scalajs.sbtplugin.Implicits._
+
+object WorkbenchBasePlugin extends AutoPlugin {
+
+  override def requires = ScalaJSPlugin
+
+  object autoImport {
+    val localUrl = settingKey[(String, Int)]("localUrl")
+
+    val sjs = inputKey[Unit]("Run a command via the sjs REPL, which compiles it to Javascript and runs it in the browser")
+    val replFile = taskKey[File]("The temporary file which holds the source code for the currently executing sjs REPL")
+    val sjsReset = taskKey[Unit]("Reset the currently executing sjs REPL")
+  }
+  import autoImport._
+  import ScalaJSPlugin.AutoImport._
+
+  val server = settingKey[Server]("local websocket server")
+
+  lazy val replHistory = collection.mutable.Buffer.empty[String]
+
+  val workbenchSettings = Seq(
+    localUrl := ("localhost", 12345),
+    (extraLoggers in ThisBuild) := {
+      val clientLogger = FullLogger{
+        new Logger {
+          def log(level: Level.Value, message: => String) =
+            if(level >= Level.Info) server.value.Wire[Api].print(level.toString, message).call()
+          def success(message: => String) = server.value.Wire[Api].print("info", message).call()
+          def trace(t: => Throwable) = server.value.Wire[Api].print("error", t.toString).call()
+        }
+      }
+      clientLogger.setSuccessEnabled(true)
+      val currentFunction = extraLoggers.value
+      (key: ScopedKey[_]) => clientLogger +: currentFunction(key)
+    },
+    server := new Server(localUrl.value._1, localUrl.value._2),
+    (onUnload in Global) := { (onUnload in Global).value.compose{ state =>
+      server.value.kill()
+      state
+    }}
+  ) ++ inConfig(Compile)(Seq(
+    artifactPath in sjs := crossTarget.value / "repl.js",
+    replFile := {
+      val f = sourceManaged.value / "repl.scala"
+      sbt.IO.write(f, replHistory.mkString("\n"))
+      f
+    },
+    sources in Compile += replFile.value,
+    sjs := Def.inputTaskDyn {
+      import sbt.complete.Parsers._
+      val str = sbt.complete.Parsers.any.*.parsed.mkString
+      val newSnippet = s"""
+          @scalajs.js.annotation.JSExport object O${replHistory.length}{
+            $str
+          };
+          import O${replHistory.length}._
+        """
+      replHistory.append(newSnippet)
+      Def.taskDyn {
+        // Basically C&Ped from fastOptJS, since we dont want this
+        // special mode from triggering updateBrowsers or similar
+        val s = streams.value
+        val output = (artifactPath in sjs).value
+
+        val taskCache = WritableFileVirtualTextFile(s.cacheDirectory / "fastopt-js")
+
+        sbt.IO.createDirectory(output.getParentFile)
+
+        val relSourceMapBase =
+          if ((relativeSourceMaps in fastOptJS).value)
+            Some(output.getParentFile.toURI())
+          else None
+
+        // TODO: re-enable this feature for latest scalajs
+        // NOTE: maybe use 'scalaJSOptimizerOptions in fullOptJS'
+        // (scalaJSOptimizer in fastOptJS).value.optimizeCP(
+        //   (scalaJSPreLinkClasspath in fastOptJS).value,
+        //   Config(
+        //     output = WritableFileVirtualJSFile(output),
+        //     cache = None,
+        //     wantSourceMap = (emitSourceMaps in fastOptJS).value,
+        //     relativizeSourceMapBase = relSourceMapBase,
+        //     checkIR = (scalaJSOptimizerOptions in fastOptJS).value.checkScalaJSIR,
+        //     disableOptimizer = (scalaJSOptimizerOptions in fastOptJS).value.disableOptimizer,
+        //     batchMode = (scalaJSOptimizerOptions in fastOptJS).value.batchMode
+        //     ),
+        //   s.log
+        // )
+        // end of C&P
+        val outPath = sbt.IO.relativize(
+          baseDirectory.value,
+          (artifactPath in sjs).value
+        ).get
+
+        sbt.IO.write(
+          (artifactPath in sjs).value,
+          sbt.IO.read(output) + s"\n\nO${replHistory.length - 1}()"
+        )
+        Def.task {
+          server.value.Wire[Api].run(
+            s"http://localhost:12345/$outPath"
+          ).call()
+          ()
+        }
+      }.dependsOn(packageJSDependencies, packageScalaJSLauncher, compile)
+    },
+    sjsReset := {
+      println("Clearing sjs REPL History")
+      replHistory.clear()
+    },
+    sjsReset := sjsReset.triggeredBy(fastOptJS)
+  ))
+
+  override def projectSettings = workbenchSettings
+
+}

--- a/src/main/scala/workbench/WorkbenchBasePlugin.scala
+++ b/src/main/scala/workbench/WorkbenchBasePlugin.scala
@@ -14,10 +14,6 @@ object WorkbenchBasePlugin extends AutoPlugin {
 
   object autoImport {
     val localUrl = settingKey[(String, Int)]("localUrl")
-
-    val sjs = inputKey[Unit]("Run a command via the sjs REPL, which compiles it to Javascript and runs it in the browser")
-    val replFile = taskKey[File]("The temporary file which holds the source code for the currently executing sjs REPL")
-    val sjsReset = taskKey[Unit]("Reset the currently executing sjs REPL")
   }
   import autoImport._
   import ScalaJSPlugin.AutoImport._
@@ -46,78 +42,7 @@ object WorkbenchBasePlugin extends AutoPlugin {
       server.value.kill()
       state
     }}
-  ) ++ inConfig(Compile)(Seq(
-    artifactPath in sjs := crossTarget.value / "repl.js",
-    replFile := {
-      val f = sourceManaged.value / "repl.scala"
-      sbt.IO.write(f, replHistory.mkString("\n"))
-      f
-    },
-    sources in Compile += replFile.value,
-    sjs := Def.inputTaskDyn {
-      import sbt.complete.Parsers._
-      val str = sbt.complete.Parsers.any.*.parsed.mkString
-      val newSnippet = s"""
-          @scalajs.js.annotation.JSExport object O${replHistory.length}{
-            $str
-          };
-          import O${replHistory.length}._
-        """
-      replHistory.append(newSnippet)
-      Def.taskDyn {
-        // Basically C&Ped from fastOptJS, since we dont want this
-        // special mode from triggering updateBrowsers or similar
-        val s = streams.value
-        val output = (artifactPath in sjs).value
-
-        val taskCache = WritableFileVirtualTextFile(s.cacheDirectory / "fastopt-js")
-
-        sbt.IO.createDirectory(output.getParentFile)
-
-        val relSourceMapBase =
-          if ((relativeSourceMaps in fastOptJS).value)
-            Some(output.getParentFile.toURI())
-          else None
-
-        // TODO: re-enable this feature for latest scalajs
-        // NOTE: maybe use 'scalaJSOptimizerOptions in fullOptJS'
-        // (scalaJSOptimizer in fastOptJS).value.optimizeCP(
-        //   (scalaJSPreLinkClasspath in fastOptJS).value,
-        //   Config(
-        //     output = WritableFileVirtualJSFile(output),
-        //     cache = None,
-        //     wantSourceMap = (emitSourceMaps in fastOptJS).value,
-        //     relativizeSourceMapBase = relSourceMapBase,
-        //     checkIR = (scalaJSOptimizerOptions in fastOptJS).value.checkScalaJSIR,
-        //     disableOptimizer = (scalaJSOptimizerOptions in fastOptJS).value.disableOptimizer,
-        //     batchMode = (scalaJSOptimizerOptions in fastOptJS).value.batchMode
-        //     ),
-        //   s.log
-        // )
-        // end of C&P
-        val outPath = sbt.IO.relativize(
-          baseDirectory.value,
-          (artifactPath in sjs).value
-        ).get
-
-        sbt.IO.write(
-          (artifactPath in sjs).value,
-          sbt.IO.read(output) + s"\n\nO${replHistory.length - 1}()"
-        )
-        Def.task {
-          server.value.Wire[Api].run(
-            s"http://localhost:12345/$outPath"
-          ).call()
-          ()
-        }
-      }.dependsOn(packageJSDependencies, packageScalaJSLauncher, compile)
-    },
-    sjsReset := {
-      println("Clearing sjs REPL History")
-      replHistory.clear()
-    },
-    sjsReset := sjsReset.triggeredBy(fastOptJS)
-  ))
+  )
 
   override def projectSettings = workbenchSettings
 

--- a/src/main/scala/workbench/WorkbenchPlugin.scala
+++ b/src/main/scala/workbench/WorkbenchPlugin.scala
@@ -10,182 +10,26 @@ import org.scalajs.sbtplugin.Implicits._
 
 object WorkbenchPlugin extends AutoPlugin {
 
-  override def requires = ScalaJSPlugin
+  override def requires = WorkbenchBasePlugin
 
   object autoImport {
     val refreshBrowsers = taskKey[Unit]("Sends a message to all connected web pages asking them to refresh the page")
-    val updatedJS = taskKey[List[String]]("Provides the addresses of the JS files that have changed")
-    val spliceBrowsers = taskKey[Unit]("Attempts to do a live update of the code running in the browser while maintaining state")
-    val localUrl = settingKey[(String, Int)]("localUrl")
-
-    val sjs = inputKey[Unit]("Run a command via the sjs REPL, which compiles it to Javascript and runs it in the browser")
-    val replFile = taskKey[File]("The temporary file which holds the source code for the currently executing sjs REPL")
-    val sjsReset = taskKey[Unit]("Reset the currently executing sjs REPL")
   }
   import autoImport._
+  import WorkbenchBasePlugin.autoImport._
+  import WorkbenchBasePlugin.server
   import ScalaJSPlugin.AutoImport._
 
-  val server = settingKey[Server]("local websocket server")
-
-  lazy val replHistory = collection.mutable.Buffer.empty[String]
-
   val workbenchSettings = Seq(
-    localUrl := ("localhost", 12345),
-    (extraLoggers in ThisBuild) := {
-      val clientLogger = FullLogger{
-        new Logger {
-          def log(level: Level.Value, message: => String) =
-            if(level >= Level.Info) server.value.Wire[Api].print(level.toString, message).call()
-          def success(message: => String) = server.value.Wire[Api].print("info", message).call()
-          def trace(t: => Throwable) = server.value.Wire[Api].print("error", t.toString).call()
-        }
-      }
-      clientLogger.setSuccessEnabled(true)
-      val currentFunction = extraLoggers.value
-      (key: ScopedKey[_]) => clientLogger +: currentFunction(key)
-    },
     refreshBrowsers := {
       streams.value.log.info("workbench: Reloading Pages...")
       server.value.Wire[Api].reload().call()
     },
     // this currently requires the old <<= syntax
     // see https://github.com/sbt/sbt/issues/1444
-    refreshBrowsers <<= refreshBrowsers.triggeredBy(fastOptJS in Compile),
-    updatedJS := {
-      var files: List[String] = Nil
-      ((crossTarget in Compile).value * "*.js").get.foreach {
-        (x: File) =>
-          streams.value.log.info("workbench: Checking " + x.getName)
-          FileFunction.cached(streams.value.cacheDirectory / x.getName, FilesInfo.lastModified, FilesInfo.lastModified) {
-            (f: Set[File]) =>
-              val fsPath = f.head.getAbsolutePath.drop(new File("").getAbsolutePath.length)
-              files = fsPath :: files
-              f
-          }(Set(x))
-      }
-      files
-    },
-    updatedJS := {
-      val paths = updatedJS.value
-      val url = localUrl.value
-      paths.map { path =>
-        s"http://${url._1}:${url._2}$path"
-      }
-    },
-    spliceBrowsers := {
-      val changed = updatedJS.value
-      // There is no point in clearing the browser if no js files have changed.
-      if (changed.length > 0) {
-        for{
-          path <- changed
-          if !path.endsWith(".js.js")
-        }{
-          streams.value.log.info("workbench: Splicing " + path)
-          val url = localUrl.value
-          val prefix = s"http://${url._1}:${url._2}/"
-          val s = munge(sbt.IO.read(new sbt.File(path.drop(prefix.length))))
-
-          sbt.IO.write(new sbt.File(path.drop(prefix.length) + ".js"), s.getBytes)
-          server.value.Wire[Api].run(path + ".js").call()
-        }
-      }
-    },
-    server := new Server(localUrl.value._1, localUrl.value._2),
-    (onUnload in Global) := { (onUnload in Global).value.compose{ state =>
-      server.value.kill()
-      state
-    }}
-  ) ++ inConfig(Compile)(Seq(
-    artifactPath in sjs := crossTarget.value / "repl.js",
-    replFile := {
-      val f = sourceManaged.value / "repl.scala"
-      sbt.IO.write(f, replHistory.mkString("\n"))
-      f
-    },
-    sources in Compile += replFile.value,
-    sjs := Def.inputTaskDyn {
-      import sbt.complete.Parsers._
-      val str = sbt.complete.Parsers.any.*.parsed.mkString
-      val newSnippet = s"""
-          @scalajs.js.annotation.JSExport object O${replHistory.length}{
-            $str
-          };
-          import O${replHistory.length}._
-        """
-      replHistory.append(newSnippet)
-      Def.taskDyn {
-        // Basically C&Ped from fastOptJS, since we dont want this
-        // special mode from triggering updateBrowsers or similar
-        val s = streams.value
-        val output = (artifactPath in sjs).value
-
-        val taskCache = WritableFileVirtualTextFile(s.cacheDirectory / "fastopt-js")
-
-        sbt.IO.createDirectory(output.getParentFile)
-
-        val relSourceMapBase =
-          if ((relativeSourceMaps in fastOptJS).value)
-            Some(output.getParentFile.toURI())
-          else None
-
-        // TODO: re-enable this feature for latest scalajs 
-        // NOTE: maybe use 'scalaJSOptimizerOptions in fullOptJS'
-        // (scalaJSOptimizer in fastOptJS).value.optimizeCP(
-        //   (scalaJSPreLinkClasspath in fastOptJS).value,
-        //   Config(
-        //     output = WritableFileVirtualJSFile(output),
-        //     cache = None,
-        //     wantSourceMap = (emitSourceMaps in fastOptJS).value,
-        //     relativizeSourceMapBase = relSourceMapBase,
-        //     checkIR = (scalaJSOptimizerOptions in fastOptJS).value.checkScalaJSIR,
-        //     disableOptimizer = (scalaJSOptimizerOptions in fastOptJS).value.disableOptimizer,
-        //     batchMode = (scalaJSOptimizerOptions in fastOptJS).value.batchMode
-        //     ),
-        //   s.log
-        // )
-        // end of C&P
-        val outPath = sbt.IO.relativize(
-          baseDirectory.value,
-          (artifactPath in sjs).value
-        ).get
-
-        sbt.IO.write(
-          (artifactPath in sjs).value,
-          sbt.IO.read(output) + s"\n\nO${replHistory.length - 1}()"
-        )
-        Def.task {
-          server.value.Wire[Api].run(
-            s"http://localhost:12345/$outPath"
-          ).call()
-          ()
-        }
-      }.dependsOn(packageJSDependencies, packageScalaJSLauncher, compile)
-    },
-    sjsReset := {
-      println("Clearing sjs REPL History")
-      replHistory.clear()
-    },
-    sjsReset := sjsReset.triggeredBy(fastOptJS)
-  ))
+    refreshBrowsers <<= refreshBrowsers.triggeredBy(fastOptJS in Compile)
+  )
 
   override def projectSettings = workbenchSettings
 
-  def munge(s0: String) = {
-    var s = s0
-    s = s.replace("\nvar ScalaJS = ", "\nvar ScalaJS = ScalaJS || ")
-    s = s.replaceAll(
-      "\n(ScalaJS\\.c\\.[a-zA-Z_$0-9]+\\.prototype) = (.*?\n)",
-      """
-        |$1 = $1 || {}
-        |(function(){
-        |  var newProto = $2
-        |  for (var attrname in newProto) { $1[attrname] = newProto[attrname]; }
-        |})()
-        |""".stripMargin
-    )
-    for(char <- Seq("d", "c", "h", "i", "n", "m")){
-      s = s.replaceAll("\n(ScalaJS\\." + char + "\\.[a-zA-Z_$0-9]+) = ", "\n$1 = $1 || ")
-    }
-    s
-  }
 }

--- a/src/main/scala/workbench/WorkbenchSplicePlugin.scala
+++ b/src/main/scala/workbench/WorkbenchSplicePlugin.scala
@@ -1,0 +1,88 @@
+package com.lihaoyi.workbench
+import scala.concurrent.ExecutionContext.Implicits.global
+import sbt._
+import sbt.Keys._
+import autowire._
+import org.scalajs.sbtplugin.ScalaJSPlugin
+import org.scalajs.core.tools.io._
+import org.scalajs.sbtplugin.ScalaJSPluginInternal._
+import org.scalajs.sbtplugin.Implicits._
+
+object WorkbenchSplicePlugin extends AutoPlugin {
+
+  override def requires = WorkbenchPlugin
+
+  object autoImport {
+    val updatedJS = taskKey[List[String]]("Provides the addresses of the JS files that have changed")
+    val spliceBrowsers = taskKey[Unit]("Attempts to do a live update of the code running in the browser while maintaining state")
+  }
+  import autoImport._
+  import WorkbenchBasePlugin.autoImport._
+  import WorkbenchBasePlugin.server
+  import ScalaJSPlugin.AutoImport._
+
+  val spliceSettings = Seq(
+    updatedJS := {
+      var files: List[String] = Nil
+      ((crossTarget in Compile).value * "*.js").get.foreach {
+        (x: File) =>
+          streams.value.log.info("workbench: Checking " + x.getName)
+          FileFunction.cached(streams.value.cacheDirectory / x.getName, FilesInfo.lastModified, FilesInfo.lastModified) {
+            (f: Set[File]) =>
+              val fsPath = f.head.getAbsolutePath.drop(new File("").getAbsolutePath.length)
+              files = fsPath :: files
+              f
+          }(Set(x))
+      }
+      files
+    },
+    updatedJS := {
+      val paths = updatedJS.value
+      val url = localUrl.value
+      paths.map { path =>
+        s"http://${url._1}:${url._2}$path"
+      }
+    },
+    spliceBrowsers := {
+      val changed = updatedJS.value
+      // There is no point in clearing the browser if no js files have changed.
+      if (changed.length > 0) {
+        for{
+          path <- changed
+          if !path.endsWith(".js.js")
+        }{
+          streams.value.log.info("workbench: Splicing " + path)
+          val url = localUrl.value
+          val prefix = s"http://${url._1}:${url._2}/"
+          val s = munge(sbt.IO.read(new sbt.File(path.drop(prefix.length))))
+
+          sbt.IO.write(new sbt.File(path.drop(prefix.length) + ".js"), s.getBytes)
+          server.value.Wire[Api].run(path + ".js").call()
+        }
+      }
+    },
+    spliceBrowsers <<= spliceBrowsers.triggeredBy(fastOptJS in Compile)
+  )
+    
+  override def projectSettings = spliceSettings
+
+  def munge(s0: String) = {
+    var s = s0
+    s = s.replace("\nvar ScalaJS = ", "\nvar ScalaJS = ScalaJS || ")
+    s = s.replaceAll(
+      "\n(ScalaJS\\.c\\.[a-zA-Z_$0-9]+\\.prototype) = (.*?\n)",
+      """
+        |$1 = $1 || {}
+        |(function(){
+        |  var newProto = $2
+        |  for (var attrname in newProto) { $1[attrname] = newProto[attrname]; }
+        |})()
+        |""".stripMargin
+    )
+    for(char <- Seq("d", "c", "h", "i", "n", "m")){
+      s = s.replaceAll("\n(ScalaJS\\." + char + "\\.[a-zA-Z_$0-9]+) = ", "\n$1 = $1 || ")
+    }
+    s
+  }
+
+}


### PR DESCRIPTION
A general update of the plugin and example. Main features include:

- [x] upgrade sbt to 0.13.13 and make the plugin an AutoPlugin
- [x] upgrade ScalaJS to 0.6.13 and dependencies
- [x] remove in-place js update capabilities, `fastOptJS` is fast enough to make `updateBrowsers` obsolete
- [x] clean build of left-over dependencies
- [x] upgrade http dependencies -> unfortunately we can't use Akka Http since it requires scala 2.11+ (which sbt 0.13 does not support), hence we'll just stick with spray as it currently is
- [x] separate reloading strategies into distinct plugins
- [x] update documentation