### PR TITLE
* improvement: enable user to configure when workbench server should start

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,18 @@ enablePlugins(WorkbenchPlugin)
 
 Once the above installation steps are completed, simply open your desired HTML file via `http://localhost:12345` with the URL path being any file part relative to your project root. e.g. `localhost:12345/target/scala-2.12/classes/index.html`. This should serve up the HTML file and connect it to workbench.
 
+#### Server Starting Behaviour
+
+By default, the server starts up when sbt loads. Ie, starting the sbt terminal via `sbt` will start the server as well.
+This behaviour can be changed by adding on of the following settings to your `build.sbt`:
+- start the server on compilation (eg when running `sbt "~fastOptJS"`)
+```scala
+workbenchStartMode := WorkbenchStartModes.OnCompile
+```
+- start the server manually using the `startWorkbenchServer` task
+```scala
+workbenchStartMode := WorkbenchStartModes.Manual
+```
 
 # Live Reloading
 


### PR DESCRIPTION
Up to now the workbench web server started whenever sbt was started. This is particular annoying when having a multi-project setup. In order to work properly, one needs to start the frontend project first, before starting the backend, otherwise workbench won't work properly.

With this change, you can enable the workbench plugin only for the frontend project (which was possible previously, but didn't bring much, since the server still started anyway on sbt load), and have it only started when running `sbt "~frontend/fastOptJS"`.

The three settings are:

- start the server on sbt startup, eg when starting the `sbt` terminal (this is the default, so same as existing behaviour)
```scala
workbenchStartMode := WorkbenchStartModes.OnSbtLoad
```
- start the server on compilation (eg only when running `sbt "~fastOptJS"`)
```scala
workbenchStartMode := WorkbenchStartModes.OnCompile
```
- start the server manually using the `startWorkbenchServer` task
```scala
workbenchStartMode := WorkbenchStartModes.Manual
```