### PR TITLE
introduced a defaultRootObject

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,10 @@ enablePlugins(WorkbenchPlugin)
 
 Once the above installation steps are completed, simply open your desired HTML file via `http://localhost:12345` with the URL path being any file part relative to your project root. e.g. `localhost:12345/target/scala-2.12/classes/index.html`. This should serve up the HTML file and connect it to workbench.
 
+If you want to serve a defaultRootObject on `http://localhost:12345` and serve only files from a root directory you can set this via:
+```scala
+workbenchDefaultRootObject := Some(("build/index-dev.html", "build/"))  // (defaultRootObject, rootDirectory) 
+```
 
 # Live Reloading
 

--- a/src/main/scala/workbench/Server.scala
+++ b/src/main/scala/workbench/Server.scala
@@ -28,7 +28,7 @@ import scala.tools.nsc.util.{JavaClassPath, DirectoryClassPath}
 import spray.http.HttpHeaders._
 import spray.http.HttpMethods._
 
-class Server(url: String, port: Int) extends SimpleRoutingApp{
+class Server(url: String, port: Int, defaultRootObject: Option[String] = None, rootDirectory: Option[String] = None) extends SimpleRoutingApp{
   val corsHeaders: List[ModeledHeader] =
     List(
       `Access-Control-Allow-Methods`(OPTIONS, GET, POST),
@@ -120,7 +120,10 @@ class Server(url: String, port: Int) extends SimpleRoutingApp{
           """
         }
       } ~
-      getFromDirectory(".")
+      pathSingleSlash {
+        getFromFile(defaultRootObject.getOrElse(""))
+      } ~
+      getFromDirectory(rootDirectory.getOrElse("."))
 
     } ~
     post {

--- a/src/main/scala/workbench/WorkbenchBasePlugin.scala
+++ b/src/main/scala/workbench/WorkbenchBasePlugin.scala
@@ -14,6 +14,7 @@ object WorkbenchBasePlugin extends AutoPlugin {
 
   object autoImport {
     val localUrl = settingKey[(String, Int)]("localUrl")
+    val workbenchDefaultRootObject = settingKey[Option[(String, String)]]("path to defaultRootObject served on `/` and rootDirectory")
   }
   import autoImport._
   import ScalaJSPlugin.AutoImport._
@@ -24,6 +25,7 @@ object WorkbenchBasePlugin extends AutoPlugin {
 
   val workbenchSettings = Seq(
     localUrl := ("localhost", 12345),
+    workbenchDefaultRootObject := None,
     (extraLoggers in ThisBuild) := {
       val clientLogger = FullLogger{
         new Logger {
@@ -37,7 +39,7 @@ object WorkbenchBasePlugin extends AutoPlugin {
       val currentFunction = extraLoggers.value
       (key: ScopedKey[_]) => clientLogger +: currentFunction(key)
     },
-    server := new Server(localUrl.value._1, localUrl.value._2),
+    server := new Server(localUrl.value._1, localUrl.value._2, workbenchDefaultRootObject.value.map(_._1), workbenchDefaultRootObject.value.map(_._2)),
     (onUnload in Global) := { (onUnload in Global).value.compose{ state =>
       server.value.kill()
       state


### PR DESCRIPTION
This change allows you to serve a defaultRootObject on `http://localhost:12345`. 
The default behaviour doesn't change, as this is an optional setting.

This is a fix to my interpretation of #26.
