### PR TITLE
Fix issue #45

### DIFF
--- a/client/src/main/scala/workbench/WorkbenchClient.scala
+++ b/client/src/main/scala/workbench/WorkbenchClient.scala
@@ -35,7 +35,7 @@ object WorkbenchClient extends Api {
   @JSExport
   def main(host: String, port: Int): Unit = {
     def rec(): Unit = {
-      Ajax.post(s"/notifications").onComplete {
+      Ajax.post(s"http://$host:$port/notifications").onComplete {
         case util.Success(data) =>
           if (!success) println("Workbench connected")
           success = true


### PR DESCRIPTION
This PR is an attempt to re-add host and port to Ajax request for notify workbench server. To be able to integrate workbench to other backend server like Play scala framework. We need the ability to define host and port for Workbench ajax request. Any idea?